### PR TITLE
Potential fix for code scanning alert no. 83: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/localcontentupdater-src.yml
+++ b/.github/workflows/localcontentupdater-src.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "**/*"
   pull_request:
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/LocalContentUpdater-src/security/code-scanning/83](https://github.com/cooljeanius/LocalContentUpdater-src/security/code-scanning/83)

Add an explicit top-level `permissions` block to the workflow so `GITHUB_TOKEN` is minimally scoped by default.  
Best single fix (without changing functionality): define workflow-level permissions as:

- `contents: read`

This is sufficient for `actions/checkout` and typical read-only CI tasks (`configure`, `make`, `make check`) and avoids granting implicit write scopes.

Edit only `.github/workflows/localcontentupdater-src.yml`, inserting the `permissions` block after the `on:` trigger section (before `jobs:`), so it applies to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
